### PR TITLE
ER - update 4 child protection indicators

### DIFF
--- a/Child protection with parental drug or alcohol misuse.R
+++ b/Child protection with parental drug or alcohol misuse.R
@@ -61,6 +61,8 @@ adp <- readRDS(paste0(profiles_lookups, "/Geography/DataZone11_All_Geographies_L
 
 
 # Make a pop lookup (all need 0-17y, with age groups and sex splits for Scotland)
+# in thepry could use scotpho population lookup under18 files as pop source but simpler to code from phs lookups
+# but not worth recoding
 
 popfile <- readRDS("/conf/linkage/output/lookups/Unicode/Populations/Estimates/CA2019_pop_est_1981_2023.rds") %>%
   filter(age<18) %>%
@@ -113,6 +115,7 @@ pop_lookup <- rbind(pop_la,
   ungroup()
 
 # repeat 2023 data for 2024: (have added this to the caveats column)
+# when indicator is updated in future the correc 2024 population should be applied and historic rates corrected
 pop_lookup_incl_2024 <- pop_lookup %>%
   filter(trend_axis == 2023) %>%
   mutate(trend_axis = 2024) %>%


### PR DESCRIPTION
Importing the latest data, including splits. Changing the way it's read in - from the original xlsx files from SG rather than a spreadsheet we keep and edit each year. Some differences in numerators found, but I confirmed the current ones are correct (currently). Also altered the denominator used for the children on the child protection register indicator. The definition and the denominators used previously were under 16, but the data are for under 18s (even the previous data). Have edited the technical document to reflect this. 