### PR TITLE
AP - Alcohol related deaths/hospitalisations

### DIFF
--- a/Alcohol related hospital stays.R
+++ b/Alcohol related hospital stays.R
@@ -231,6 +231,8 @@ popgroups_data <- rbind(males, females, all) |>
 saveRDS(popgroups_data, file.path(profiles_data_folder, "Data to be checked", "alcohol_stays_shiny_popgrp.rds"))
 write.csv(popgroups_data, file.path(profiles_data_folder, "Data to be checked", "alcohol_stays_shiny_popgrp.csv"), row.names = FALSE)
 
+run_qa(filename="alcohol_stays", type="popgrp")
+
 # delete individual male/female files from the data to be checked folder
 file.remove(file.path(profiles_data_folder, "Data to be checked", "alcohol_stays_females_shiny.rds"))
 file.remove(file.path(profiles_data_folder, "Data to be checked", "alcohol_stays_females_shiny.csv"))

--- a/Alcohol related hospital stays.R
+++ b/Alcohol related hospital stays.R
@@ -3,7 +3,7 @@
 #   Alcohol-related hospital stays (ages 11 to 25 years) (13024)
 
 # Not to be confused with mental health indicator Hospital stays for mental or behavioural disorders due to alcohol (30006)
-# in R script Alc-related hosp stays - mental and behav.R
+# in R script Alc-related hosp stays - mental and behav.R (the mental health indicator sources data from SMR04 psychiatric hospital admissions)
 
 #   Part 1 - Extract data from SMRA and tidy up
 #   Part 2 - Create the different geographies basefiles

--- a/Alcohol related hospital stays.R
+++ b/Alcohol related hospital stays.R
@@ -1,10 +1,15 @@
-#    ScotPHO indicators: 3 indicator outputs from this script 
-#   Alcohol-related hospital stays (all ages) indicator, 
-#   Alcohol-related hospital stays (all ages) inequalities indicator and 
-#   Alcohol-related hospital stays (ages 11 to 25 years) indicator
+#    ScotPHO indicators: 
+#   Alcohol-related hospital stays (all ages) indicator (20203)
+#   Alcohol-related hospital stays (ages 11 to 25 years) (13024)
 
-#   Part 1 - Extract data from SMRA.
+# Not to be confused with mental health indicator Hospital stays for mental or behavioural disorders due to alcohol (30006)
+# in R script Alc-related hosp stays - mental and behav.R
+
+#   Part 1 - Extract data from SMRA and tidy up
 #   Part 2 - Create the different geographies basefiles
+#        2a - Aggregate admissions up to datazones
+#        2b - Combine dz01 and dz11 data to assign each datazone to correct SIMD quintile
+#        2c - Create council-level data file for 11-25 year olds
 #   Part 3 - Run analysis functions 
 
 ###############################################.
@@ -12,10 +17,9 @@
 ###############################################.
 library(lubridate) #requires lubridate to derive financial year of stay
 
-source("1.indicator_analysis.R") #Normal indicator functions
-source("2.deprivation_analysis.R") # deprivation function
+source("./functions/main_analysis.R") #Normal indicator functions
+source("./functions/deprivation_analysis.R") # deprivation function
 source("//PHI_conf/ScotPHO/Profiles/Code/stat_disclosure_alcohol_stays.R") # statistical disclosure methodology - confidential - do not share
-
 
 ###############################################.
 ## Part 1 - Extract data from SMRA ----
@@ -26,11 +30,13 @@ channel <- suppressWarnings(dbConnect(odbc(),  dsn="SMRA",
                                       pwd=.rs.askForPassword("SMRA Password:")))
 
 # Extract alcohol stay CIS data 
-# This extraction should give figures that match the methodology used by ISD alcohol 
+# This extraction should give figures that match the methodology used by PHS alcohol 
 # team who publish national statistics for alcohol related admissions.
 # ScotPHO should not publish updated indicator until after the national 
 # statistics publication has been released.
-# Diagnostic codes should match those use by the ISD ARHS national statistics publication.  
+#https://publichealthscotland.scot/publications/show-all-releases?id=20558
+
+# Diagnostic codes should match those use by the PHS ARHS national statistics publication.  
 # The codes used may differ from alcohol related deaths indicators since
 # alcohol related deaths focus on conditions wholly attributable to alcohol.
 
@@ -43,24 +49,25 @@ channel <- suppressWarnings(dbConnect(odbc(),  dsn="SMRA",
 # data from 2001 if you want to be sure to capture all CIS that end in 2002/03 and year after required period
 # to ensure capture episode when CIS ends)
 
-alc_diag <- "E244|E512|F10|G312|G621|G721|I426|K292|K70|K852|K860|O354|P043|Q860|R780|T510|T511|T519|X45|X65|Y15|Y573|Y90|Y91|Z502|Z714|Z721"
+#Code list reviewed April 2026 against publication linked above
 
+alc_diag <- "E244|E512|F10|G312|G621|G721|I426|K292|K70[0-4]|K709|K852|K860|O354|P043|Q860|R780|T510|T511|T519|X45|X65|Y15|Y573|Y90|Y91|Z502|Z714|Z721"
 
 ## ANALYSTS RUNNING AN UPDATE : remember to update the year in both parts of the SQL extraction (there are 2 places because this is a sub-query)
-##  Also set the end point to the year after you want data (so if you need data for 2022/23 then the date between filter should end '31 March 2024' ) - I know that this is odd and the FYE won't be complete yet but this indicator is a bit unsual as its based on FYE of discharge.
+##  Also set the end point to the year after you want data (so if you need data for 2022/23 then the date between filter should end '31 March 2024' ) - I know that this is odd and the FYE won't be complete yet but this indicator is a bit unusual as its based on FYE of discharge.
 ## theres a filter later in the script that restricts the data you end up with
 
 data_alcohol_episodes <- as_tibble(dbGetQuery(channel, statement= paste0(
   "SELECT link_no linkno, cis_marker cis, AGE_IN_YEARS age, admission_date, 
       discharge_date, DR_POSTCODE pc7, SEX sex_grp, ADMISSION, DISCHARGE, URI
   FROM ANALYSIS.SMR01_PI z
-  WHERE discharge_date between  '1 April 2001' and '31 March 2025'
+  WHERE discharge_date between  '1 April 2001' and '31 March 2026'
       and sex <> 9
       and exists (
           select * 
           from ANALYSIS.SMR01_PI  
           where link_no=z.link_no and cis_marker=z.cis_marker
-            and discharge_date between '1 April 2001' and '31 March 2025'
+            and discharge_date between '1 April 2001' and '31 March 2026'
             and (regexp_like(main_condition, '", alc_diag ,"')
               or regexp_like(other_condition_1,'", alc_diag ,"')
               or regexp_like(other_condition_2,'", alc_diag ,"')
@@ -80,7 +87,7 @@ data_alcoholstays <- data_alcohol_episodes  %>%
             ddisch=last(discharge_date),
             staymonth=month(ddisch),
             year = case_when(staymonth >3 ~ year(ddisch), staymonth <= 3 ~ year(ddisch)-1, TRUE ~ 0)) %>% # generate financial year of stay field
-  subset(year>=2002 & year <2024) %>% # this is where you restrict the dataset to only the years you need for the profile indicator (the SQl extraction returns extra years to cover the fact some CIS will span more than one FYE)
+  subset(year>=2002 & year <2025) %>% # this is where you restrict the dataset to only the years you need for the profile indicator (the SQl extraction returns extra years to cover the fact some CIS will span more than one FYE)
   ungroup() %>% 
   # Creating age groups for standardization.
   create_agegroups()
@@ -89,7 +96,7 @@ data_alcoholstays <- data_alcohol_episodes  %>%
 xtabs(~data_alcoholstays$year)
 
 # Bringing CA and datazone info.
-postcode_lookup <- read_rds('/conf/linkage/output/lookups/Unicode/Geography/Scottish Postcode Directory/Scottish_Postcode_Directory_2024_2.rds') %>%
+postcode_lookup <- read_rds('/conf/linkage/output/lookups/Unicode/Geography/Scottish Postcode Directory/Scottish_Postcode_Directory_2026_1.rds') %>%
   setNames(tolower(names(.)))  #variables to lower case
 
 # Match geography information (datazone) to stays data
@@ -105,17 +112,17 @@ data_alcoholstays <- data_alcoholstays %>%
 ## Part 2 - Create the different geographies basefiles ----
 ###############################################.
 ###############################################.
-# Datazone2011
+
+# 2a - Aggregate admissions to get count of admissions by age and sex per dz per year
 dz11 <- data_alcoholstays %>% 
   group_by(year, datazone2011, sex_grp, age_grp) %>%  
-  summarize(numerator = n()) %>% ungroup() %>%  rename(datazone = datazone2011)
-
-saveRDS(dz11, file=paste0(data_folder, 'Prepared Data/alcohol_stays_dz11_raw.rds'))
-datadz <- readRDS(paste0(data_folder, 'Prepared Data/alcohol_stays_dz11_raw.rds')) %>%
+  summarize(numerator = n()) %>% ungroup() %>%  rename(datazone = datazone2011) |> 
   mutate_if(is.character, factor)
 
+saveRDS(dz11, file.path(profiles_data_folder, 'Prepared Data/alcohol_stays_dz11_raw.rds'))
+
 ###############################################.
-#Deprivation basefile
+# 2b - combine dz01 and dz11 data to assign each datazone to SIMD quintile
 # DZ 2001 data needed up to 2013 to enable matching to advised SIMD
 
 dz01_dep <- data_alcoholstays %>% 
@@ -125,10 +132,10 @@ dz01_dep <- data_alcoholstays %>%
 
 dep_file <- rbind(dz01_dep, dz11 %>% subset(year>=2014)) #joining dz01 and dz11
 
-saveRDS(dep_file, file=paste0(data_folder, 'Prepared Data/alcohol_stays_depr_raw.rds'))
+saveRDS(dep_file, file.path(profiles_data_folder, 'Prepared Data/alcohol_stays_depr_raw.rds'))
 
 ###############################################.
-# CA (council area) file for separate indicator in CYP profile for those aged 11 to 25 years
+# 2c - CA (council area) file for 11-25 year old indicator
 
 alcoholstays_11to25 <- data_alcoholstays %>%
   subset(age>=11 & age<=25) %>% 
@@ -137,20 +144,18 @@ alcoholstays_11to25 <- data_alcoholstays %>%
   ungroup() %>%   
   rename(ca = ca2019)
 
-saveRDS(alcoholstays_11to25, file=paste0(data_folder, 'Prepared Data/alcohol_stays_11to25_raw.rds'))
+saveRDS(alcoholstays_11to25, file.path(profiles_data_folder, 'Prepared Data/alcohol_stays_11to25_raw.rds'))
 
 ###############################################.
 ## Part 3 - Run analysis functions ----
 ###############################################.
 ###############################################.
-##Run macros to generate HWB and Alcohol Profile indicator data
-# All ages alcohol related hospital stays 
-analyze_first(filename = "alcohol_stays_dz11", geography = "datazone11", measure = "stdrate", 
-              pop = "DZ11_pop_allages", yearstart = 2002, yearend = 2023,
-              time_agg = 1, epop_age = "normal",  adp = TRUE)
 
-analyze_second(filename = "alcohol_stays_dz11", measure = "stdrate", time_agg = 1, 
-               epop_total = 200000, ind_id = 20203, year_type = "financial")
+# All ages alcohol related hospital stays 
+main_analysis(filename = "alcohol_stays_dz11", geography = "datazone11", measure = "stdrate",
+              pop = "DZ11_pop_allages", yearstart = 2002, yearend = 2024,
+              time_agg = 1, epop_age = "normal", epop_total = 200000, ind_id = 20203,
+              year_type = "financial")
 
 apply_stats_disc("alcohol_stays_dz11_shiny") # statistical disclosure applied to final values
 
@@ -162,15 +167,10 @@ analyze_deprivation(filename="alcohol_stays_depr", measure="stdrate", time_agg=1
 
 apply_stats_disc("alcohol_stays_depr_ineq") # statistical disclosure applied to final values to ensure consistency with other profile indicators
 
-###############################################.
-##Run macros again to generate CYP indicator data
 # Alcohol related stays in 11 to 25 year olds
-analyze_first(filename = "alcohol_stays_11to25", geography = "council", measure = "stdrate", 
-              pop = "CA_pop_11to25", yearstart = 2002, yearend = 2023,
-              time_agg = 3, epop_age = '11to25', adp=TRUE)
-
-analyze_second(filename = "alcohol_stays_11to25", measure = "stdrate", time_agg = 3, 
-               epop_total = 34200, ind_id = 13024, year_type = "financial")
+main_analysis(filename = "alcohol_stays_11to25", geography = "council", measure = "stdrate",
+              pop = "CA_pop_11to25", yearstart = 2002, yearend = 2024, time_agg = 3,
+              epop_age = "11to25", epop_total = 34200, ind_id = 13024, year_type = "financial")
 
 apply_stats_disc("alcohol_stays_11to25_shiny") # statistical disclosure applied to final values
 

--- a/Alcohol related hospital stays.R
+++ b/Alcohol related hospital stays.R
@@ -9,7 +9,8 @@
 #   Part 2 - Create the different geographies basefiles
 #        2a - Aggregate admissions up to datazones
 #        2b - Combine dz01 and dz11 data to assign each datazone to correct SIMD quintile
-#        2c - Create council-level data file for 11-25 year olds
+#        2c - Create population groups file
+#        2d - Create council-level data file for 11-25 year olds
 #   Part 3 - Run analysis functions 
 
 ###############################################.
@@ -110,6 +111,10 @@ data_alcoholstays <- data_alcoholstays %>%
   subset(!(is.na(datazone2011))) %>%  #select out non-scottish
   mutate_if(is.character, factor) # converting variables into factors
 
+#Saving data so can be re-read in if running over multiple sessions due to long search duration
+saveRDS(data_alcoholstays, file.path(profiles_data_folder, "Prepared Data/alcohol_stays_raw_extract.rds"))
+data_alcoholstays <- readRDS(file.path(profiles_data_folder, "Prepared Data/alcohol_stays_raw_extract.rds"))
+
 ###############################################.
 ## Part 2 - Create the different geographies basefiles ----
 ###############################################.
@@ -137,7 +142,27 @@ dep_file <- rbind(dz01_dep, dz11 %>% subset(year>=2014)) #joining dz01 and dz11
 saveRDS(dep_file, file.path(profiles_data_folder, 'Prepared Data/alcohol_stays_depr_raw.rds'))
 
 ###############################################.
-# 2c - CA (council area) file for 11-25 year old indicator
+# 2c - create pop groups files
+
+#Create two files split by sex then run through analysis functions. To do dz or council?
+alcoholstays_males <- data_alcoholstays |> 
+  filter(sex_grp == 1) |> 
+  group_by(year, ca2019, age_grp, sex_grp) |> 
+  summarise(numerator = n(), .groups = "drop") |> 
+  rename(ca = ca2019)
+
+saveRDS(alcoholstays_males, file.path(profiles_data_folder, 'Prepared Data/alcohol_stays_males_raw.rds'))
+
+alcoholstays_females <- data_alcoholstays |> 
+  filter(sex_grp == 2) |> 
+  group_by(year, ca2019, age_grp, sex_grp) |> 
+  summarise(numerator = n(), .groups = "drop") |> 
+  rename(ca = ca2019)
+
+saveRDS(alcoholstays_females, file.path(profiles_data_folder, 'Prepared Data/alcohol_stays_females_raw.rds'))
+
+###############################################.
+# 2d - CA (council area) file for 11-25 year old indicator
 
 alcoholstays_11to25 <- data_alcoholstays %>%
   subset(age>=11 & age<=25) %>% 
@@ -168,6 +193,49 @@ analyze_deprivation(filename="alcohol_stays_depr", measure="stdrate", time_agg=1
                     epop_total =200000, ind_id = 20203)
 
 apply_stats_disc("alcohol_stays_depr_ineq") # statistical disclosure applied to final values to ensure consistency with other profile indicators
+
+
+#Alcohol stays in males and females
+main_analysis(filename = "alcohol_stays_males", geography = "council", measure = "stdrate",
+              pop = "CA_pop_allages", yearstart = 2002, yearend = 2024,
+              time_agg = 1, epop_age = "normal", epop_total = 100000, ind_id = 20203,
+              year_type = "financial")
+
+apply_stats_disc("alcohol_stays_males_shiny")
+
+main_analysis(filename = "alcohol_stays_females", geography = "council", measure = "stdrate",
+              pop = "CA_pop_allages", yearstart = 2002, yearend = 2024,
+              time_agg = 1, epop_age = "normal", epop_total = 100000, ind_id = 20203,
+              year_type = "financial")
+
+apply_stats_disc("alcohol_stays_females_shiny")
+
+#read male and female results back in and combine with main analysis results (i.e. totals)
+males <- readRDS(file.path(profiles_data_folder, "Data to be checked", "alcohol_stays_males_shiny.rds")) |> 
+  mutate(split_value = "Males")
+
+females <- readRDS(file.path(profiles_data_folder, "Data to be checked", "alcohol_stays_females_shiny.rds")) |> 
+  mutate(split_value = "Females")
+
+all <- readRDS(file.path(profiles_data_folder, "Data to be checked", "alcohol_stays_dz11_shiny.rds")) |>
+  mutate(split_value = "All")
+
+# combine into one dataset
+# filter on Scotland, council, board and HSCP only
+# dont want to report IZ/HSC locality level sex splits as too granular
+popgroups_data <- rbind(males, females, all) |>
+  mutate(split_name = "Sex") |>
+  filter(grepl("S00|S12|S08|S11", code))
+
+# save final file 
+saveRDS(popgroups_data, file.path(profiles_data_folder, "Data to be checked", "alcohol_stays_shiny_popgrp.rds"))
+write.csv(popgroups_data, file.path(profiles_data_folder, "Data to be checked", "alcohol_stays_shiny_popgrp.csv"), row.names = FALSE)
+
+# delete individual male/female files from the data to be checked folder
+file.remove(file.path(profiles_data_folder, "Data to be checked", "alcohol_stays_females_shiny.rds"))
+file.remove(file.path(profiles_data_folder, "Data to be checked", "alcohol_stays_females_shiny.csv"))
+file.remove(file.path(profiles_data_folder, "Data to be checked", "alcohol_stays_males_shiny.rds"))
+file.remove(file.path(profiles_data_folder, "Data to be checked", "alcohol_stays_males_shiny.csv"))
 
 # Alcohol related stays in 11 to 25 year olds
 main_analysis(filename = "alcohol_stays_11to25", geography = "council", measure = "stdrate",

--- a/Alcohol related hospital stays.R
+++ b/Alcohol related hospital stays.R
@@ -144,7 +144,7 @@ saveRDS(dep_file, file.path(profiles_data_folder, 'Prepared Data/alcohol_stays_d
 ###############################################.
 # 2c - create pop groups files
 
-#Create two files split by sex then run through analysis functions. To do dz or council?
+#Create two files split by sex then run through analysis functions
 alcoholstays_males <- data_alcoholstays |> 
   filter(sex_grp == 1) |> 
   group_by(year, ca2019, age_grp, sex_grp) |> 

--- a/Alcohol related hospital stays.R
+++ b/Alcohol related hospital stays.R
@@ -57,6 +57,8 @@ alc_diag <- "E244|E512|F10|G312|G621|G721|I426|K292|K70[0-4]|K709|K852|K860|O354
 ##  Also set the end point to the year after you want data (so if you need data for 2022/23 then the date between filter should end '31 March 2024' ) - I know that this is odd and the FYE won't be complete yet but this indicator is a bit unusual as its based on FYE of discharge.
 ## theres a filter later in the script that restricts the data you end up with
 
+#Make sure to use a large session size as this query takes a long time to run!
+
 data_alcohol_episodes <- as_tibble(dbGetQuery(channel, statement= paste0(
   "SELECT link_no linkno, cis_marker cis, AGE_IN_YEARS age, admission_date, 
       discharge_date, DR_POSTCODE pc7, SEX sex_grp, ADMISSION, DISCHARGE, URI

--- a/Alcohol related mortality.R
+++ b/Alcohol related mortality.R
@@ -96,41 +96,33 @@ saveRDS(dep_file, file.path(profiles_data_folder, 'Prepared Data/alcohol_deaths_
 
 # CA file for gender specific indicators in Alcohol profile
 # Female alcohol mortality
+#Create two files split by sex then run through analysis functions
+alcohol_deaths_males <- data_deaths |> 
+  filter(sex_grp == 1) |> 
+  group_by(year, ca2019, age_grp, sex_grp) |> 
+  summarise(numerator = n(), .groups = "drop") |> 
+  rename(ca = ca2019)
 
+saveRDS(alcohol_deaths_males, file.path(profiles_data_folder, 'Prepared Data/alcohol_deaths_males_raw.rds'))
 
-alcohol_deaths_female <- data_deaths %>%
-  subset(sex_grp==2) %>% 
-  group_by(year, datazone2011, sex_grp, age_grp) %>%  
-  summarize(numerator = n()) %>% 
-  ungroup() %>%   
-  rename(datazone = datazone2011)
+alcohol_deaths_females <- data_deaths |> 
+  filter(sex_grp == 2) |> 
+  group_by(year, ca2019, age_grp, sex_grp) |> 
+  summarise(numerator = n(), .groups = "drop") |> 
+  rename(ca = ca2019)
 
-saveRDS(alcohol_deaths_female, file=paste0(data_folder, 'Prepared Data/alcohol_deaths_female_raw.rds'))
-
-###############################################.
-# CA (council area) file for gender specific indicators in Alcohol profile
-# Male alcohol mortality
-
-alcohol_deaths_male <- data_deaths %>%
-  subset(sex_grp==1) %>% 
-  group_by(year, datazone2011, sex_grp, age_grp) %>%  
-  summarize(numerator = n()) %>% 
-  ungroup() %>%   
-  rename(datazone = datazone2011)
-
-saveRDS(alcohol_deaths_male, file=paste0(data_folder, 'Prepared Data/alcohol_deaths_male_raw.rds'))
+saveRDS(alcohol_deaths_females, file.path(profiles_data_folder, 'Prepared Data/alcohol_deaths_females_raw.rds'))
 
 ###############################################.
 ## Part 3 - Run analysis functions ----
 ###############################################.
 
 #Alcohol mortality indicator functions
-analyze_first(filename = "alcohol_deaths_dz11", geography = "datazone11", adp=TRUE, measure = "stdrate", 
-              pop = "DZ11_pop_allages", yearstart = 2002, yearend = 2023,
-              time_agg = 5, epop_age = "normal")
+main_analysis(filename = "alcohol_deaths_dz11", geography = "datazone11", measure = "stdrate",
+              pop = "DZ11_pop_allages", yearstart = 2002, yearend = 2024, time_agg = 5, 
+              epop_age = "normal", epop_total = 200000, ind_id = 20204, year_type = "calendar")
 
-analyze_second(filename = "alcohol_deaths_dz11", measure = "stdrate", time_agg = 5, 
-               epop_total = 200000, ind_id = 20204, year_type = "calendar")
+
 
 ###############################################.
 #Alcohol mortality by deprivation indicator functions
@@ -140,39 +132,47 @@ analyze_deprivation(filename="alcohol_deaths_depr", measure="stdrate", time_agg=
                     epop_age="normal", epop_total =200000, ind_id = 20204)
 
 ###############################################.
-#FEMALE Alcohol mortality indicator functions
-#Set to produce IZ level data to allow production of ADP, HSCP and council data but IZ and locality data excluded from final dataset
-analyze_first(filename = "alcohol_deaths_female", geography = "datazone11", measure = "stdrate", 
-              pop = "DZ11_pop_allages", yearstart = 2002, yearend = 2023,
-              adp=TRUE, time_agg = 5, epop_age = "normal")
 
-#open output of analyze first and exclude IZ and locality data
-data_indicator <- readRDS(file=paste0(data_folder, "Temporary/alcohol_deaths_female_formatted.rds"))
-data_indicator <- data_indicator %>%
-  subset(substr(code, 1, 3)!="S02" & substr(code,1,3)!="S99") 
+#Alcohol deaths in males and females
+main_analysis(filename = "alcohol_deaths_males", geography = "council", measure = "stdrate",
+              pop = "CA_pop_allages", yearstart = 2002, yearend = 2024,
+              time_agg = 5, epop_age = "normal", epop_total = 100000, ind_id = 20204,
+              year_type = "calendar")
 
-saveRDS(data_indicator, file=paste0(data_folder, "Temporary/alcohol_deaths_female_formatted.rds"))
+apply_stats_disc("alcohol_deaths_males_shiny")
 
+main_analysis(filename = "alcohol_deaths_females", geography = "council", measure = "stdrate",
+              pop = "CA_pop_allages", yearstart = 2002, yearend = 2024,
+              time_agg = 5, epop_age = "normal", epop_total = 100000, ind_id = 20204,
+              year_type = "calendar")
 
-#epop is only 100000 as only female half population
-analyze_second(filename = "alcohol_deaths_female", measure = "stdrate", time_agg = 5, 
-               epop_total = 100000, ind_id = 12537, year_type = "calendar")
+apply_stats_disc("alcohol_deaths_females_shiny")
 
-###############################################.
-#MALE Alcohol mortality indicator functions
-analyze_first(filename = "alcohol_deaths_male", geography = "datazone11", measure = "stdrate", 
-              pop = "DZ11_pop_allages", yearstart = 2002, yearend = 2023,
-              adp=TRUE, time_agg = 5, epop_age = "normal")
+#read male and female results back in and combine with main analysis results (i.e. totals)
+males <- readRDS(file.path(profiles_data_folder, "Data to be checked", "alcohol_deaths_males_shiny.rds")) |> 
+  mutate(split_value = "Males")
 
-#open output of analyze first and exclude IZ and locality data
-data_indicator <- readRDS(file=paste0(data_folder, "Temporary/alcohol_deaths_male_formatted.rds"))
-data_indicator <- data_indicator %>%
-  subset(substr(code, 1, 3)!="S02" & substr(code,1,3)!="S99") 
+females <- readRDS(file.path(profiles_data_folder, "Data to be checked", "alcohol_deaths_females_shiny.rds")) |> 
+  mutate(split_value = "Females")
 
-saveRDS(data_indicator, file=paste0(data_folder, "Temporary/alcohol_deaths_male_formatted.rds"))
+all <- readRDS(file.path(profiles_data_folder, "Data to be checked", "alcohol_deaths_dz11_shiny.rds")) |>
+  mutate(split_value = "All")
 
-#epop is only 100000 as only male half population
-analyze_second(filename = "alcohol_deaths_male", measure = "stdrate", time_agg = 5, 
-               epop_total = 100000, ind_id = 12536, year_type = "calendar")
+# combine into one dataset
+# filter on Scotland, council, board and HSCP only
+# dont want to report IZ/HSC locality level sex splits as too granular
+popgroups_data <- rbind(males, females, all) |>
+  mutate(split_name = "Sex") |>
+  filter(grepl("S00|S12|S08|S11", code))
+
+# save final file 
+saveRDS(popgroups_data, file.path(profiles_data_folder, "Data to be checked", "alcohol_deaths_shiny_popgrp.rds"))
+write.csv(popgroups_data, file.path(profiles_data_folder, "Data to be checked", "alcohol_deaths_shiny_popgrp.csv"), row.names = FALSE)
+
+# delete individual male/female files from the data to be checked folder
+file.remove(file.path(profiles_data_folder, "Data to be checked", "alcohol_stays_females_shiny.rds"))
+file.remove(file.path(profiles_data_folder, "Data to be checked", "alcohol_stays_females_shiny.csv"))
+file.remove(file.path(profiles_data_folder, "Data to be checked", "alcohol_stays_males_shiny.rds"))
+file.remove(file.path(profiles_data_folder, "Data to be checked", "alcohol_stays_males_shiny.csv"))
 
 #END

--- a/Alcohol related mortality.R
+++ b/Alcohol related mortality.R
@@ -1,19 +1,23 @@
 # ScotPHO indicators: 
-# Alcohol specific mortality (5 year aggregate) (Scotland, NHS Board, CA, ADP, HSCP Partnership 
-# & Locality - IZ data generated but not included in shiny tool to reduce disclosure risk)
-# Alcohol specific mortality by Deprivation (5 year aggregate)
-# Female alcohol related mortality (5 year aggregate) (Scotland, NHS Board, CA, ADP  only - IZ/HSCP/Locality data generated but excluded after data production)
-# Male alcohol related mortality (5 year aggregate) (Scotland, NHS Board, CA, ADP only  - IZ/HSCP/Locality data generated but excluded after data production)
+# Alcohol specific mortality (20204)
+
+# files produced:
+# main: Y 
+# poproups: Y (sex splits)
+# deprivation: Y 
 
 #   Part 1 - Extract data from SMRA - Deaths file.
 #   Part 2 - Create the different geographies basefiles
-#   Part 3 - Run macros
+#        2a - Aggregate admissions up to datazones
+#        2b - Combine dz01 and dz11 data to assign each datazone to correct SIMD quintile
+#        2c - Create council-level data file for pop groups file
+#   Part 3 - Run analysis functions
 
 ###############################################.
 ## Packages/Filepaths/Functions ----
 ###############################################.
-source("1.indicator_analysis.R") #Normal indicator functions
-source("2.deprivation_analysis.R") # deprivation function
+source("./functions/main_analysis.R") #Normal indicator functions
+source("./functions/deprivation_analysis.R") # deprivation function
 
 ###############################################.
 ## Part 1 - Extract data from SMRA ----
@@ -28,14 +32,15 @@ channel <- suppressWarnings(dbConnect(odbc(),  dsn="SMRA",
 # Exclude any with null age group
 # Exclude deaths where sex is unknown (9)
 # Selections based on primary cause of death 
-# ICD10 codes to match NRS definitions of alcohol-specific deaths (ie wholly attributable to alcohol) 
+# ICD10 codes to match NRS definitions of alcohol-specific deaths (ie wholly attributable to alcohol)
+# ICD10 codes reviewed and revised April 2026 against NRS publication
 
 data_deaths <- tibble::as_tibble(dbGetQuery(channel, statement=
  "SELECT year_of_registration year, age, SEX sex_grp, POSTCODE pc7
   FROM ANALYSIS.GRO_DEATHS_C 
-  WHERE date_of_registration between '1 January 2002' AND '31 December 2023'
+  WHERE date_of_registration between '1 January 2002' AND '31 December 2024'
         AND country_of_residence ='XS'
-        AND regexp_like(underlying_cause_of_death,'E244|F10|G312|G621|G721|I426|K292|K70|K852|K860|Q860|R78|X45|X65|Y15|E860') 
+        AND regexp_like(underlying_cause_of_death,'E244|F10|G312|G621|G721|I426|K292|K70|K852|K860|Q860|R780|X45|X65|Y15') 
         AND age is not NULL
         AND sex <> 9")) %>%
   setNames(tolower(names(.)))  #variables to lower case
@@ -44,7 +49,7 @@ data_deaths <- tibble::as_tibble(dbGetQuery(channel, statement=
 data_deaths <- data_deaths %>% create_agegroups()
 
 # Open LA and datazone info.
-postcode_lookup <- read_rds('/conf/linkage/output/lookups/Unicode/Geography/Scottish Postcode Directory/Scottish_Postcode_Directory_2024_2.rds') %>%
+postcode_lookup <- read_rds('/conf/linkage/output/lookups/Unicode/Geography/Scottish Postcode Directory/Scottish_Postcode_Directory_2026_1.rds') %>%
   setNames(tolower(names(.)))  #variables to lower case
 
 data_deaths <- left_join(data_deaths, postcode_lookup, "pc7") %>% 
@@ -56,36 +61,42 @@ data_deaths <- left_join(data_deaths, postcode_lookup, "pc7") %>%
 ## Part 2 - Create denominator files for the different geographies basefiles ----
 ###############################################.
 ###############################################.
+
+#2a - Aggregate deaths up to datazones
+
 # Datazone2011
 dz11 <- data_deaths %>% 
   group_by(year, datazone2011, sex_grp, age_grp) %>%  
-  summarize(numerator = n()) %>% ungroup() %>%  rename(datazone = datazone2011)
+  summarize(numerator = n(), .groups = "drop") %>% rename(datazone = datazone2011)
 
-saveRDS(dz11, file=paste0(data_folder, 'Prepared Data/alcohol_deaths_dz11_raw.rds'))
-datadz <- readRDS(paste0(data_folder, 'Prepared Data/alcohol_deaths_dz11_raw.rds'))
+saveRDS(dz11, file.path(profiles_data_folder, 'Prepared Data/alcohol_deaths_dz11_raw.rds'))
 
-# Datazone2001. Only used for IRs
+# Datazone2001 - used for data from 2002-2011
 dz01 <- data_deaths %>% group_by(year, datazone2001, sex_grp, age_grp) %>%  
-  summarize(numerator = n()) %>% ungroup() %>% subset(year<2011) %>% rename(datazone = datazone2001)
+  summarize(numerator = n(), .groups = "drop") %>% subset(year<2011) %>% rename(datazone = datazone2001)
 
-saveRDS(dz01, file=paste0(data_folder, 'Prepared Data/alchohol_deaths_dz01_raw.rds'))
+saveRDS(dz01, file.path(profiles_data_folder, 'Prepared Data/alchohol_deaths_dz01_raw.rds'))
 
 ###############################################.
-#Deprivation indicator numerator file
+#2b - Create deprivation basefile
 
 # Datazone2001. DZ 2001 data needed up to 2013 to enable matching to advised SIMD
 dz01_dep <- data_deaths %>% group_by(year, datazone2001, sex_grp, age_grp) %>%  
-  summarize(numerator = n()) %>% ungroup() %>% subset(year<=2013) %>% rename(datazone = datazone2001)
+  summarize(numerator = n(), .groups = "drop") %>% subset(year<=2013) %>% rename(datazone = datazone2001)
 
 # Deprivation basefile
 dep_file <- dz11 %>% subset(year>=2014)
 dep_file <- rbind(dz01_dep, dep_file) #joining together
 
-saveRDS(dep_file, file=paste0(data_folder, 'Prepared Data/alcohol_deaths_depr_raw.rds'))
+saveRDS(dep_file, file.path(profiles_data_folder, 'Prepared Data/alcohol_deaths_depr_raw.rds'))
 
 ###############################################.
+#2c - Create popgroups basefile
+
+
 # CA file for gender specific indicators in Alcohol profile
 # Female alcohol mortality
+
 
 alcohol_deaths_female <- data_deaths %>%
   subset(sex_grp==2) %>% 

--- a/Alcohol related mortality.R
+++ b/Alcohol related mortality.R
@@ -18,6 +18,7 @@
 ###############################################.
 source("./functions/main_analysis.R") #Normal indicator functions
 source("./functions/deprivation_analysis.R") # deprivation function
+source("//PHI_conf/ScotPHO/Profiles/Code/stat_disclosure_alcohol_stays.R") # statistical disclosure methodology - confidential - do not share
 
 ###############################################.
 ## Part 1 - Extract data from SMRA ----
@@ -123,7 +124,6 @@ main_analysis(filename = "alcohol_deaths_dz11", geography = "datazone11", measur
               epop_age = "normal", epop_total = 200000, ind_id = 20204, year_type = "calendar")
 
 
-
 ###############################################.
 #Alcohol mortality by deprivation indicator functions
 analyze_deprivation(filename="alcohol_deaths_depr", measure="stdrate", time_agg=5, 
@@ -139,14 +139,11 @@ main_analysis(filename = "alcohol_deaths_males", geography = "council", measure 
               time_agg = 5, epop_age = "normal", epop_total = 100000, ind_id = 20204,
               year_type = "calendar")
 
-apply_stats_disc("alcohol_deaths_males_shiny")
-
 main_analysis(filename = "alcohol_deaths_females", geography = "council", measure = "stdrate",
               pop = "CA_pop_allages", yearstart = 2002, yearend = 2024,
               time_agg = 5, epop_age = "normal", epop_total = 100000, ind_id = 20204,
               year_type = "calendar")
 
-apply_stats_disc("alcohol_deaths_females_shiny")
 
 #read male and female results back in and combine with main analysis results (i.e. totals)
 males <- readRDS(file.path(profiles_data_folder, "Data to be checked", "alcohol_deaths_males_shiny.rds")) |> 
@@ -165,14 +162,11 @@ popgroups_data <- rbind(males, females, all) |>
   mutate(split_name = "Sex") |>
   filter(grepl("S00|S12|S08|S11", code))
 
-# save final file 
+# save file 
 saveRDS(popgroups_data, file.path(profiles_data_folder, "Data to be checked", "alcohol_deaths_shiny_popgrp.rds"))
 write.csv(popgroups_data, file.path(profiles_data_folder, "Data to be checked", "alcohol_deaths_shiny_popgrp.csv"), row.names = FALSE)
 
-# delete individual male/female files from the data to be checked folder
-file.remove(file.path(profiles_data_folder, "Data to be checked", "alcohol_stays_females_shiny.rds"))
-file.remove(file.path(profiles_data_folder, "Data to be checked", "alcohol_stays_females_shiny.csv"))
-file.remove(file.path(profiles_data_folder, "Data to be checked", "alcohol_stays_males_shiny.rds"))
-file.remove(file.path(profiles_data_folder, "Data to be checked", "alcohol_stays_males_shiny.csv"))
+#finally apply disclosure
+apply_stats_disc("alcohol_deaths_shiny_popgrp")
 
 #END

--- a/Alcohol related mortality.R
+++ b/Alcohol related mortality.R
@@ -166,8 +166,15 @@ popgroups_data <- rbind(males, females, all) |>
 saveRDS(popgroups_data, file.path(profiles_data_folder, "Data to be checked", "alcohol_deaths_shiny_popgrp.rds"))
 write.csv(popgroups_data, file.path(profiles_data_folder, "Data to be checked", "alcohol_deaths_shiny_popgrp.csv"), row.names = FALSE)
 
+# Call pop group QA to check output
+run_qa(filename="alcohol_deaths", type="popgrp")
+
+
 # delete single sex alcohol deaths indicators as these are no longer distinct indicators and we don't want files moved to shiny data folder
 file.remove(file.path(profiles_data_folder, "Data to be checked", "alcohol_deaths_females_shiny.rds"))
 file.remove(file.path(profiles_data_folder, "Data to be checked", "alcohol_deaths_males_shiny.rds"))
+file.remove(file.path(profiles_data_folder, "Data to be checked", "alcohol_deaths_females_shiny.csv"))
+file.remove(file.path(profiles_data_folder, "Data to be checked", "alcohol_deaths_males_shiny.csv"))
+
 
 #END

--- a/Alcohol related mortality.R
+++ b/Alcohol related mortality.R
@@ -166,7 +166,8 @@ popgroups_data <- rbind(males, females, all) |>
 saveRDS(popgroups_data, file.path(profiles_data_folder, "Data to be checked", "alcohol_deaths_shiny_popgrp.rds"))
 write.csv(popgroups_data, file.path(profiles_data_folder, "Data to be checked", "alcohol_deaths_shiny_popgrp.csv"), row.names = FALSE)
 
-#finally apply disclosure
-apply_stats_disc("alcohol_deaths_shiny_popgrp")
+# delete single sex alcohol deaths indicators as these are no longer distinct indicators and we don't want files moved to shiny data folder
+file.remove(file.path(profiles_data_folder, "Data to be checked", "alcohol_deaths_females_shiny.rds"))
+file.remove(file.path(profiles_data_folder, "Data to be checked", "alcohol_deaths_males_shiny.rds"))
 
 #END


### PR DESCRIPTION
Hi both,

Here are 2024/25 updates to:
- Alcohol-related hospital admissions
- Alcohol-related hospital admissions in 11-25 year olds
- Alcohol-specific deaths

Changes include
- Addition of pop groups file with sex splits for admissions
- Replacement alcohol-specific deaths in males and females indicators with a pop groups file. I've changed these indicators from being dz based to council as we were removing iz and locality figures anyway. The numerators for males and females do tally with totals despite using different geography bases - is there another reason for running at dz level I'm not thinking of?
- Slight fix to ICD10 codes in deaths query. R78 was used previously which refers to all substances in the blood (e.g. steroids, opiates) whereas R780 is used by NRS and refers to alcohol only. The change seems to have had no impact on numerators thankfully, probably because we're only looking at underlying cause of death. 

Let me know if you spot any issues. 