### PR TITLE
disability pay gap - add 2020-2023 data and confidence intervals

### DIFF
--- a/Disability Pay Gap.R
+++ b/Disability Pay Gap.R
@@ -5,14 +5,13 @@
 #Indicator: Disability Pay Gap (Indicator ID 99138)
 # Description: Percentage point gap in median hourly pay between disabled and non-disabled employees
 
-# Data source is Labour Market Statistics for Scotland by Disability: January to December 2022 supporting tables:
-#(specifically Table_15) 
-#https://www.gov.scot/publications/labour-market-statistics-for-scotland-by-disability-january-to-december-2022/documents/
+# Data sourced from 'Raw disability pay gaps UK' ONS tables (created using Annual Population Survey):
+# https://www.ons.gov.uk/peoplepopulationandcommunity/healthandsocialcare/disability/datasets/rawpaygapsbydisability
 
-# Note that data only up to 2019. The accuracy of income weights are affected by an issue with the coding of 
-# occupations identified by ONS. ONS have advised earnings information should be used with caution for 
-# later years therefore SG publication excludes more recent years data until the issue is resolved.
-
+# Note APS based labour market statistics are now classified as 'Official Statistics under development'
+# due to ongoing challenges with response rates, levels, and weighting approach mean
+# See 'Note' tab of the excel table. 
+# Estimates used here are considered robust for full time series (check statistical robustness column of Table 5)
 
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 # Packages/Filepaths/Functions ----
@@ -26,31 +25,36 @@ library(readxl)
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 # read in downloaded data
-disability_data <- read_xlsx(file.path(profiles_data_folder, "Received Data", "Disability pay gap/Labour+Market+Statistics+for+Scotland+by+Disability+Tables=.xlsx"), sheet = "Table_15", skip = 6) %>%
-  setNames(tolower(names(.))) %>% #variables to lower case
-  rename(rate = "disability pay gap [note 25]")
+disability_data <- read_xlsx(file.path(profiles_data_folder, "Received Data/Disability pay gap", "dpgrawpaygaps2024.xlsx"), sheet = "Table 5", skip = 5)
+
 
 
 # clean data 
 disability_data <- disability_data %>%
   
-  # select relevant columns
-  select(year, rate) %>%
+  # clean column names
+  clean_names() %>%
+
+  # filter on relevant rows
+  filter(disability_status == "Disabled employees" & country_and_english_region == "Scotland") %>%
   
-  #remove unnecessary rows
-  filter(!grepl("Change", year)) %>%
+  # select and rename columns
+  select(
+    year, 
+    rate = pay_gap_percent,
+    upci = pay_gap_ucl_percent,
+    lowci = pay_gap_lcl_percent
+    ) %>%
   
-  #remove [r] from year names
-  mutate(year = as.numeric(gsub("\\[r\\]", "", year))) %>%
+  # convert rate, upci and lowci columns to class numeric
+  mutate(across(c("rate", "upci", "lowci"), ~ as.numeric(.))) %>%
+  
 
   mutate(ind_id = 99138,
-         rate = rate*100,
          #trend axis is field which populates the year axis in charts (needs to be short simple description of the time period that will display nicely in a chart)
          trend_axis = as.character(year), 
          #def_period is field that appears in indicator meta data which can be a more expansive description of the type of year (calendar/financial) and, if applicable, details about rolling averages    
          def_period = paste0(year, " survey year"),
-         lowci = as.numeric(NA), 
-         upci = as.numeric(NA),
          numerator = as.numeric(NA),
          code = "S00000001" ) %>% #assign the scotland code as theres no LA breakdown
   
@@ -67,7 +71,7 @@ write.csv(disability_data, file.path(profiles_data_folder, "Data to be checked/9
 write_rds(disability_data, file.path(profiles_data_folder, "Data to be checked/99138_disability_paygap_shiny.rds"))
 
 # insert call to QA report
-run_main_analysis_qa(filename = "99138_disability_paygap", test_file = FALSE) 
+run_qa(filename = "99138_disability_paygap", type = "main") 
 
 
 #END


### PR DESCRIPTION
Updating the disability pay gap indicator. This is a Scotland only indicator and previously only went up to 2019. I've found more up to date data tables from ONS website that go up to 2023 (historical data matches what we currently have).

Think there are still some ongoing challenges with APS which is the source of these stats but the statistical robustness of all the figures included in this are labelled as 'precise'. Also now included confidence intervals which were previously missing.