### PR TITLE
Ap Teen Pregnancies 2023 update

### DIFF
--- a/Teenage pregnancies.R
+++ b/Teenage pregnancies.R
@@ -6,8 +6,8 @@
 ###############################################.
 ## Packages/Filepaths/Functions ----
 ###############################################.
-source("./1.indicator_analysis.R") #Normal indicator functions
-source("./2.deprivation_analysis.R") # deprivation function
+source("./functions/main_analysis.R") #Normal indicator functions
+source("./functions/deprivation_analysis.R") # deprivation function
 
 ###############################################.
 ## Part 1 - Prepare basefile ----
@@ -16,28 +16,26 @@ source("./2.deprivation_analysis.R") # deprivation function
 # Reading data provided by maternity team
 # All data is included, but to calculate the rates only 15-19 female pop is used, 
 # following ISD publication methodology.
-teen_preg <- read_csv( paste0(data_folder, "Received Data/Teenage pregnancies/IR2024-00770.csv")) %>% 
-  setNames(tolower(names(.))) %>% #set names to lower case
+teen_preg <- read_csv(file.path(profiles_data_folder, "Received Data/Teenage pregnancies/IR2026-00003_TeenPregs.csv")) %>% 
+  clean_names() %>% #set names to lower case
   rename(datazone = datazone2011, numerator = tp, year = yearcon) %>% 
-  subset(!(is.na(datazone) | datazone == "         ")) %>% #excluding non-Scottish residents
+  subset(!(is.na(datazone) | datazone == "         " | datazone == "Unknown")) %>% #excluding non-Scottish residents
   # aggregate to get the count, removing age groups
   group_by(year, datazone) %>% 
   summarise(numerator = sum(numerator, na.rm =T)) %>% ungroup()
 
-saveRDS(teen_preg, file=paste0(data_folder, 'Prepared Data/teen_preg_raw.rds'))
+saveRDS(teen_preg, file.path(profiles_data_folder, 'Prepared Data/teen_preg_raw.rds'))
 
 ###############################################.
 ## Part 2 - Run analysis functions ----
 ###############################################.
-analyze_first(filename = "teen_preg", geography = "datazone11", measure = "crude", 
-              yearstart = 2002, yearend = 2022, time_agg = 3, pop='DZ11_pop_fem15to19')
-
-analyze_second(filename = "teen_preg", measure = "crude", time_agg = 3, crude_rate=1000,
-               ind_id = 21001, year_type = "calendar")
+main_analysis(filename = "teen_preg", geography = "datazone11", measure = "crude",
+              yearstart = 2002, yearend = 2023, time_agg = 3, pop = "DZ11_pop_fem15to19",
+              ind_id = 21001, year_type = "calendar", crude_rate = 1000)
 
 #Deprivation analysis function
-analyze_deprivation(filename="teen_preg", measure="crude", time_agg=3, crude_rate=1000,
-                    yearstart= 2014, yearend=2022, year_type = "calendar", 
-                    pop = "depr_pop_fem15to19", ind_id = 21001)
+deprivation_analysis(filename="teen_preg", measure="crude", time_agg=3, crude_rate=1000,
+                    yearstart= 2014, yearend=2023, year_type = "calendar", 
+                     ind_id = 21001)
 
 ##END

--- a/Teenage pregnancies.R
+++ b/Teenage pregnancies.R
@@ -19,7 +19,7 @@ source("./functions/deprivation_analysis.R") # deprivation function
 teen_preg <- read_csv(file.path(profiles_data_folder, "Received Data/Teenage pregnancies/IR2026-00003_TeenPregs.csv")) %>% 
   clean_names() %>% #set names to lower case
   rename(datazone = datazone2011, numerator = tp, year = yearcon) %>% 
-  mutate(datazone = dplyr::na_if(datazone, "Unknown")) |> 
+  mutate(datazone = dplyr::na_if(datazone, "Unknown")) |> #convert unknown datazones to NA so they're still included in Scotland total to align with births in Scotland publication which included non-residents. 
   # aggregate to get the count, removing age groups
   group_by(year, datazone) %>% 
   summarise(numerator = sum(numerator, na.rm =T)) %>% ungroup()

--- a/Teenage pregnancies.R
+++ b/Teenage pregnancies.R
@@ -19,7 +19,7 @@ source("./functions/deprivation_analysis.R") # deprivation function
 teen_preg <- read_csv(file.path(profiles_data_folder, "Received Data/Teenage pregnancies/IR2026-00003_TeenPregs.csv")) %>% 
   clean_names() %>% #set names to lower case
   rename(datazone = datazone2011, numerator = tp, year = yearcon) %>% 
-  subset(!(is.na(datazone) | datazone == "         " | datazone == "Unknown")) %>% #excluding non-Scottish residents
+  mutate(datazone = dplyr::na_if(datazone, "Unknown")) |> 
   # aggregate to get the count, removing age groups
   group_by(year, datazone) %>% 
   summarise(numerator = sum(numerator, na.rm =T)) %>% ungroup()
@@ -34,8 +34,8 @@ main_analysis(filename = "teen_preg", geography = "datazone11", measure = "crude
               ind_id = 21001, year_type = "calendar", crude_rate = 1000)
 
 #Deprivation analysis function
-deprivation_analysis(filename="teen_preg", measure="crude", time_agg=3, crude_rate=1000,
-                    yearstart= 2014, yearend=2023, year_type = "calendar", 
+deprivation_analysis(filename ="teen_preg", measure ="crude", time_agg = 3, crude_rate = 1000,
+                    yearstart = 2014, yearend = 2023, year_type = "calendar", 
                      ind_id = 21001)
 
 ##END

--- a/Teenage pregnancies.R
+++ b/Teenage pregnancies.R
@@ -36,6 +36,5 @@ main_analysis(filename = "teen_preg", geography = "datazone11", measure = "crude
 #Deprivation analysis function
 deprivation_analysis(filename ="teen_preg", measure ="crude", time_agg = 3, crude_rate = 1000,
                     yearstart = 2014, yearend = 2023, year_type = "calendar", 
-                     ind_id = 21001)
-
+                     ind_id = 21001, pop_sex = "female", pop_age = c(15, 19))
 ##END

--- a/Teenage pregnancies.R
+++ b/Teenage pregnancies.R
@@ -1,5 +1,7 @@
 # ScotPHO indicators: teenage pregnancies #
 
+#To do - look at adding age splits
+
 #   Part 1 - Prepare basefile
 #   Part 2 - Run analysis functions
 
@@ -15,7 +17,7 @@ source("./functions/deprivation_analysis.R") # deprivation function
 
 # Reading data provided by maternity team
 # All data is included, but to calculate the rates only 15-19 female pop is used, 
-# following ISD publication methodology.
+# following PHS publication methodology.
 teen_preg <- read_csv(file.path(profiles_data_folder, "Received Data/Teenage pregnancies/IR2026-00003_TeenPregs.csv")) %>% 
   clean_names() %>% #set names to lower case
   rename(datazone = datazone2011, numerator = tp, year = yearcon) %>% 


### PR DESCRIPTION
Hi both,

Quick update to the indicator teenage pregnancies.
Apart from the usual changes to the analysis functions the main changes are
- New data source, Scottish Linked Pregnancy and Baby Dataset (SLiPBD). Comparison shows <1% change in Scotland figures across all years compared to previously published indicator. 
- Changes to handling of NAs - previously they were removed but Mat Stats team recommend inclusion in Scotland totals to align with Births in Scotland publication. These will be a mixture of residents who could not be assigned to a datazone due to e.g. being in prison, homeless, and non-residents who gave birth in Scotland. The BiS publication measures all babies born in Scotland regardless of residency.
- These indicators haven't been run since before the rebased population estimates were released so there's further minor differences throughout the time series.

On another note, we receive these data split by age in years from the Mat Stats team so there's probably some scope to add a pop groups file with age split, but not at intermediate zone level. We could do Under 16s, 16-17 year olds and 18-19 years olds. 