### PR TITLE
Ap childhealth indicators

### DIFF
--- a/Exposure to secondhand smoke.R
+++ b/Exposure to secondhand smoke.R
@@ -6,44 +6,37 @@
 ###############################################.
 ## Packages/Filepaths/Functions ----
 ###############################################.
-source("1.indicator_analysis.R") #Normal indicator functions
+source("./functions/main_analysis.R") #Normal indicator functions
+source("./functions/data cleaning functions/fix_fin_year.R") #for converting to financial year
+source("./functions/data cleaning functions/exclude_geog_codes.R") #for removing intermediate zone data and areas w/ DQ issues
+library(readxl) #for reading in xlsx filetype
 
 ###############################################.
 ## Part 1 - Prepare basefile ----
 ###############################################.
 #data from child health team
-exposure_smoking <- read_csv(paste0(data_folder, "Received Data/Exposure to secondhand smoke/IR2023-00861_secondhandsmoke_valid.csv")) %>%
-  setNames(tolower(names(.))) %>% #set names to lower case
-  mutate(year=case_when(nchar(fin_year)==3 ~ paste0("200",substr(fin_year,1,1)), 
-                        TRUE ~ paste0("20",substr(fin_year,1,2)))) # fin year
+exposure_smoking <- read_excel(file.path(profiles_data_folder, "Received Data/Exposure to secondhand smoke/IR2026-00350_secondhandsmoke_valid.xlsx"), col_types = "text") |> 
+  janitor::clean_names() |>  #set names to lower case
+  fix_fin_year("fin_year", "2") #fix fin year
 
 #removes all other geographies apart from datazone(needed if received data contains Scotland and hb data)
-exposure_smoking <- exposure_smoking %>%
-  filter(!(is.na(datazone2011))) %>%
-  select(-ca2019) %>%
-  rename(numerator = passive_smoke_yes, denominator = totvalid_6to8wk)
+exposure_smoking <- exposure_smoking |> 
+  filter(!(is.na(datazone2011))) |> 
+  select(-ca2019, -hb_residence_desc) |> 
+  rename(numerator = passive_smoke_yes, denominator = totvalid_6to8wk) |> 
+  mutate(across(c("numerator", "denominator"), as.numeric))
+         
+saveRDS(exposure_smoking, file.path(profiles_data_folder, "Prepared Data/exposure_smoking_raw.rds"))
 
-ca_lookup <- readRDS('/conf/linkage/output/lookups/Unicode/Geography/Scottish Postcode Directory/Scottish_Postcode_Directory_2023_2.rds') %>% 
-  setNames(tolower(names(.))) %>%   #variables to lower case
-  select(datazone2011, ca2019) %>% distinct()
-
-exposure_geography <- left_join(exposure_smoking, ca_lookup, by = "datazone2011") %>% 
-  rename(ca = ca2019 ) %>% group_by(ca, year) %>% 
-  summarise(numerator = sum(numerator), denominator = sum(denominator)) %>% 
-  ungroup() %>% 
-  # Selecting out a few cases from early years in Highland CA before the system was 
-  # properly in place that would cause confusion.
-  filter(!(ca == "S12000017" & year<2007))
-
-saveRDS(exposure_geography, file=paste0(data_folder, 'Prepared Data/exposure_smoking_raw.rds'))
 
 ###############################################.
 ## Part 2 - Run analysis functions ----
 ###############################################.
-analyze_first(filename = "exposure_smoking", geography = "council", hscp = T,
-              measure = "percent", yearstart = 2002, yearend = 2022, time_agg = 3)
+main_analysis(filename = "exposure_smoking", geography = "datazone11", measure = "percent", 
+              yearstart = 2002, yearend = 2024, time_agg = 3, ind_id = 13037, year_type = "financial")
 
-analyze_second(filename = "exposure_smoking", measure = "percent", time_agg = 3,  
-               ind_id = 13037, year_type = "financial")
-
+#Exclude intermediate zones for all years due to small numbers. Remove Highland Council for years prior to 2007 as
+#system was not properly in place yet and data could cause confusion
+exclude_geog_codes(filename = "exposure_smoking", iz = TRUE, codes = c("S12000017"), codes_years = 2002:2006)
+  
 ##END

--- a/developmental concerns 27-30 months.R
+++ b/developmental concerns 27-30 months.R
@@ -8,14 +8,15 @@
 ###############################################.
 source("./functions/main_analysis.R") #Normal indicator functions
 source("./functions/deprivation_analysis.R") # deprivation function
+source("./functions/data cleaning functions/fix_fin_year.R") #fix financial year function
+library(readxl) #for reading in xlsx files
 
-library(readxl)
 ###############################################.
 ## Part 1 - Prepare basefile ----
 ###############################################.
 
 # read in the data
-dev_concerns <- read_xlsx(file.path(profiles_data_folder, "/Received Data/Developmental concerns/IR2025-00535.xlsx")) 
+dev_concerns <- read_xlsx(file.path(profiles_data_folder, "Received Data/Developmental concerns/IR2026-00349.xlsx")) 
 
 # tidy up col names
 dev_concerns <- dev_concerns |> 
@@ -23,30 +24,27 @@ dev_concerns <- dev_concerns |>
   rename(datazone = datazone2011,
          fin_year = finyr_eligible) #renaming variables to datazone and fin_year
 
-
 #removes all other geographies apart from datazone (needed if received data contains Scotland and hb data)
 dev_concerns <- dev_concerns |> 
   filter(!(is.na(datazone))|hb_residence_desc=="Unknown")
   
 dev_concerns <- dev_concerns |> 
-  mutate( #creates year field based on length of fin_year
-    year=substr(fin_year, start=1, stop=4)) |> 
+  fix_fin_year("fin_year", "4") |> #fix fin year
   group_by(year, datazone) |> 
-  summarise(numerator = sum(concerns), denominator = sum(reviews)) |> 
-  ungroup()
+  summarise(numerator = sum(concerns), denominator = sum(reviews), .groups = "drop")
 
-saveRDS(dev_concerns, file=file.path(profiles_data_folder, '/Prepared Data/dev_concerns_raw.rds')) 
-saveRDS(dev_concerns, file=file.path(profiles_data_folder, '/Prepared Data/dev_concerns_depr_raw.rds'))
+saveRDS(dev_concerns, file.path(profiles_data_folder, 'Prepared Data/dev_concerns_raw.rds')) 
 
 ###############################################.
 ## Part 2 - calling analysis functions ----
 ###############################################.
 
 main_analysis(filename = "dev_concerns", geography = "datazone11", measure = "percent", 
-              yearstart = 2013, yearend = 2023, time_agg = 3, year_type = "financial",
+              yearstart = 2013, yearend = 2024, time_agg = 3, year_type = "financial",
               ind_id = 13048)
 
-deprivation_analysis(filename = "dev_concerns", yearstart = 2013, yearend = 2023, 
+deprivation_analysis(filename = "dev_concerns", yearstart = 2013, yearend = 2024, 
                      time_agg = 3, year_type = "financial", measure = "percent", 
                      ind_id = 13048)
- 
+
+#End

--- a/functions/data cleaning functions/fix_fin_year.R
+++ b/functions/data cleaning functions/fix_fin_year.R
@@ -14,7 +14,7 @@ library(dplyr)
 library(stringr)
 library(rlang)
 
-fix_fin_year <- function(df, fy_col_name, first_year_digits = c("2", "4")){
+fix_fin_year <- function(df, fy_col_name, first_year_digits = c("2", "3", "4")){
   
   #If first_year_digits are none of 2, 3 or 4 stop the function and print an error
   if (!(first_year_digits %in% c("2", "3", "4"))) {
@@ -35,11 +35,9 @@ fix_fin_year <- function(df, fy_col_name, first_year_digits = c("2", "4")){
     df <- df |> 
       mutate(
         !!fy_col_name_sym := as.character(!!fy_col_name_sym), #convert to character in case fy provided as a number e.g. 2223
-        temp_year := as.numeric(str_sub(!!fy_col_name_sym, 1, 2)), #keep only first two digits and convert to numeric, store in temp variable
-        !!fy_col_name_sym := case_when(
-          temp_year > 50 ~ paste0("19", temp_year),  #This is guesswork for correct century!
-          TRUE ~ paste0("20", temp_year))) |> #If remaining 2 digits >50 guess 1900s, if <=50 guess 2000s
-      select(-temp_year) #drop the temporary year variable
+        !!fy_col_name_sym := case_when(as.numeric(str_sub(!!fy_col_name_sym, 1, 2)) > 50 ~ #Guesswork for correct century! If last 2 digits of first year >50,
+                                         paste0("19", str_sub(!!fy_col_name_sym, 1, 2)),  #then guess 1900s
+                                       TRUE ~paste0("20", str_sub(!!fy_col_name_sym, 1, 2)))) #if <= 50, guess 2000s
     
     #If fin year format is YYY (only a few indicators) i.e. 203 = 02/03. Likely due to Excel dropping leading zero.
   }else if(first_year_digits == "3"){


### PR DESCRIPTION
Hi Monica, 

Updates to 2x indicators for 24/25
- Exposure to second hand smoke at 6-8 week visit
- Developmental concerns at 27-30 months

Changes include:
- Minor changes to filepaths etc. for developmental concerns
- Fix to fix_fin_year functions where leading 0 in noughties years was getting dropped e.g. 0708 -> 708 -> 207 rather than 2007
- A few more tweaks to exposure to secondhand smoke, mainly running at dz11 level rather than council and then removing IZs afterwards. I'm leaving in localities for the first time as they weren't flagging up at all for low numbers. Deprivation splits could be calculated but I think a lot of suppression would be applied. 

Let me know if you spot any issues! Thanks.
